### PR TITLE
1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.1.0]
+
+### Features
+- If `cpu.performance` is defined, now the energy policy level is also set to full performance. This feature is only available for certain Intel CPUs (generally for laptop models). More on that [here](https://github.com/vinifmor/guapow/tree/cpu_epb#changing-cpu-cores-energy-policy-level-full-performance)
+
 ## [1.0.2] 2021-12-26
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.1.0]
+## [1.1.0] 2022-06-03
 
 ### Features
 - If `cpu.performance` is defined, now the energy policy level is also set to full performance. This feature is only available for certain Intel CPUs (generally for laptop models). More on that [here](https://github.com/vinifmor/guapow/tree/cpu_epb#changing-cpu-cores-energy-policy-level-full-performance)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Features
 - If `cpu.performance` is defined, now the energy policy level is also set to full performance. This feature is only available for certain Intel CPUs (generally for laptop models). More on that [here](https://github.com/vinifmor/guapow/tree/cpu_epb#changing-cpu-cores-energy-policy-level-full-performance)
 
+### Improvements
+- Optimizer settings:
+  - `launcher.mapping.timeout`: now defaults to `30` seconds instead of `15`.
+
 ## [1.0.2] 2021-12-26
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ makepkg -si
         compositor = (pre-defines the installed compositor. Options: kwin, compiz, marco, picom, compton, nvidia)
         scripts.allow_root = false (allow custom scripts/commands to run at the root level)
         check.finished.interval = 3 (finished applications checking interval in seconds)
-        launcher.mapping.timeout = 15 (max time in seconds to find the application mapped to a given launcher. float values are allowed)
+        launcher.mapping.timeout = 30 (max time in seconds to find the application mapped to a given launcher. float values are allowed)
         gpu.cache = false (if 'true': maps all available GPUs on startup. Otherwise, GPUs will be mapped for every request)
         gpu.vendor =  # pre-defines your GPU vendor for faster GPUs mapping. Supported: nvidia, amd
         cpu.performance = false  (set cpu governors and energy policy levels to full performance on startup)

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ makepkg -si
         launcher=def:def-bin   # this would map the executable 'def' to an application named 'def-bin'. So 'def-bin' would be optimized instead of 'def'
     ```
     
-    - b) Providing all mapping through the `launchers` file located in `~/.config/guapow` (for non-root users) or `/etc/guapow` (for global or root usage) following the pattern `exe_name=name_or_command`. The advantage of this approach is that you don't have to provide a per-profile/configuration mapping. But at the same time, tons of mappings will impact the matching process time. Example:
+    - b) Providing all mapping through the `launchers` file located in `~/.config/guapow` (for non-root users) or `/etc/guapow` (for global or root usage) following the pattern `exe_name=name_or_command`. The advantage of this approach is that you don't have to provide a per-profile/configuration mapping. But at the same time, tons of mappings **may** impact the matching process time. Example:
     ```
     abc=abc-full
     def=def-bin

--- a/guapow/__init__.py
+++ b/guapow/__init__.py
@@ -2,4 +2,4 @@ import os
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 __app_name__ = 'guapow'
-__version__ = '1.0.2'
+__version__ = '1.1.0'

--- a/guapow/common/config.py
+++ b/guapow/common/config.py
@@ -84,7 +84,7 @@ class OptimizerConfig(RootFileModel):
 
     def __init__(self, port: Optional[int] = None, compositor: Optional[str] = None,
                  allow_root_scripts: Optional[bool] = False,
-                 check_finished_interval: Optional[int] = None, launcher_mapping_timeout: Optional[float] = 15,
+                 check_finished_interval: Optional[int] = None, launcher_mapping_timeout: Optional[float] = 30,
                  gpu_cache: Optional[bool] = False, cpu_performance: Optional[bool] = None,
                  profile_cache: Optional[bool] = None, pre_cache_profiles: Optional[bool] = None,
                  gpu_vendor: Optional[str] = None, renicer_interval: Optional[float] = None):
@@ -146,7 +146,7 @@ class OptimizerConfig(RootFileModel):
             self.check_finished_interval = 3
 
         if not self.has_valid_launcher_mapping_timeout():
-            self.launcher_mapping_timeout = 15
+            self.launcher_mapping_timeout = 30
 
         if self.gpu_cache is None:
             self.gpu_cache = False

--- a/guapow/dist/daemon/opt.conf
+++ b/guapow/dist/daemon/opt.conf
@@ -8,7 +8,7 @@
 # launcher.mapping.timeout = 15  # max time in seconds to find the application mapped to a given launcher. float values are allowed
 # gpu.cache = false # if 'true': maps all available GPUs on startup. Otherwise, GPUs will be mapped for every request
 # gpu.vendor =  # pre-defines your GPU vendor for faster GPUs mapping. Supported: nvidia, amd
-# cpu.performance = false  # activates cpu performance governors on startup
+# cpu.performance = false  # set cpu governors and energy policy levels to full performance on startup
 # request.allowed_users =  # restricts users that can request optimizations, separated by comma. e.g: root,xpto)
 # request.encrypted = true # only accepts encrypted requests for security reasons
 # profile.cache = false # cache profile files on demand to skip I/O operations. Changes to profile files require restarting

--- a/guapow/dist/daemon/opt.conf
+++ b/guapow/dist/daemon/opt.conf
@@ -5,7 +5,7 @@
 # compositor =   # pre-defines the installed compositor. Options: kwin, compiz, marco, picom, compton, nvidia
 # scripts.allow_root = false  # allow custom scripts/commands to run at the root level
 # check.finished.interval = 3  # finished applications checking interval in seconds
-# launcher.mapping.timeout = 15  # max time in seconds to find the application mapped to a given launcher. float values are allowed
+# launcher.mapping.timeout = 30  # max time in seconds to find the application mapped to a given launcher. float values are allowed
 # gpu.cache = false # if 'true': maps all available GPUs on startup. Otherwise, GPUs will be mapped for every request
 # gpu.vendor =  # pre-defines your GPU vendor for faster GPUs mapping. Supported: nvidia, amd
 # cpu.performance = false  # set cpu governors and energy policy levels to full performance on startup

--- a/guapow/service/optimizer/cpu.py
+++ b/guapow/service/optimizer/cpu.py
@@ -118,11 +118,12 @@ class CPUEnergyPolicyManager:
 
     def can_work(self) -> Tuple[bool, Optional[str]]:
         if not self._cpus or self._cpus < 0:
-            return False, 'No CPU detected'
+            return False, 'It will not be possible to change the CPU energy policy level: no CPU detected'
 
         file_path = self._file_pattern.format(idx='0')
         if not os.path.exists(file_path):
-            return False, f'Not possible to change the CPU energy policy level. File not found: {file_path}'
+            return False, f"It will not be possible to change the CPU energy policy level: " \
+                          f"file '{file_path})' not found"
 
         return True, None
 

--- a/guapow/service/optimizer/cpu.py
+++ b/guapow/service/optimizer/cpu.py
@@ -123,7 +123,7 @@ class CPUEnergyPolicyManager:
         file_path = self._file_pattern.format(idx='0')
         if not os.path.exists(file_path):
             return False, f"It will not be possible to change the CPU energy policy level: " \
-                          f"file '{file_path})' not found"
+                          f"file '{file_path}' not found"
 
         return True, None
 

--- a/guapow/service/optimizer/cpu.py
+++ b/guapow/service/optimizer/cpu.py
@@ -1,8 +1,10 @@
 import asyncio
 import multiprocessing
+import os.path
+import traceback
 from asyncio import Lock
 from logging import Logger
-from typing import Optional, Set, Dict
+from typing import Optional, Set, Dict, Tuple
 
 import aiofiles
 
@@ -97,3 +99,99 @@ class CPUFrequencyManager:
             self._log.info(f"CPUs [{','.join((str(i) for i in changed))}] frequency governor changed to '{governor}'")
 
         return changed
+
+
+class CPUEnergyPolicyManager:
+
+    LEVEL_PERFORMANCE = 0
+
+    def __init__(self, cpu_count: int, logger: Logger,
+                 file_pattern: str = '/sys/devices/system/cpu/cpu{idx}/power/energy_perf_bias'):
+        self._cpus = cpu_count
+        self._log = logger
+        self._lock = Lock()
+        self._state_cache: Dict[int, int] = dict()
+        self._file_pattern = file_pattern
+
+    def lock(self) -> Lock:
+        return self._lock
+
+    def can_work(self) -> Tuple[bool, Optional[str]]:
+        if not self._cpus or self._cpus < 0:
+            return False, 'No CPU detected'
+
+        file_path = self._file_pattern.format(idx='0')
+        if not os.path.exists(file_path):
+            return False, f'Not possible to change the CPU energy policy level. File not found: {file_path}'
+
+        return True, None
+
+    async def _read_cpu_state(self, idx: int) -> Optional[int]:
+        file_path = self._file_pattern.format(idx=idx)
+        cpu_state = None
+
+        try:
+            async with aiofiles.open(file_path) as f:
+                cpu_state = await f.read()
+        except:
+            err_stack = traceback.format_exc().replace('\n', ' ')
+            self._log.error(f"[{self.__class__.__name__}] Could not read file '{file_path}': {err_stack}")
+
+        if cpu_state is not None:
+            try:
+                return int(cpu_state)
+            except ValueError:
+                self._log.error(f"[{self.__class__.__name__}] Could not cast CPU energy policy level ({cpu_state}) "
+                                f"to int. File: {file_path}")
+
+    async def _write_cpu_state(self, idx: int, state: int) -> bool:
+        file_path = self._file_pattern.format(idx=idx)
+
+        try:
+            async with aiofiles.open(file_path, 'w+') as f:
+                await f.write(str(state))
+
+            return True
+        except:
+            err_stack = traceback.format_exc().replace('\n', ' ')
+            self._log.error(f"[{self.__class__.__name__}] Could not write '{state}' to file '{file_path}': {err_stack}")
+            return False
+
+    async def _fill_cpu_state_change(self, idx: int, state: int, output: Dict[int, bool]):
+        output[idx] = await self._write_cpu_state(idx, state)
+
+    async def _fill_cpu_state(self, idx: int, output: Dict[int, int]):
+        cpu_state = await self._read_cpu_state(idx)
+
+        if isinstance(cpu_state, int):
+            output[idx] = cpu_state
+
+    async def map_current_state(self) -> Optional[Dict[int, int]]:
+        if self._cpus > 0:
+            res = {}
+            await asyncio.gather(*[self._fill_cpu_state(idx, res) for idx in range(self._cpus)])
+            return res if res else None
+
+    async def change_states(self, cpu_states: Dict[int, int]) -> Dict[int, bool]:
+        if self._cpus > 0 and cpu_states:
+            res = {}
+            await asyncio.gather(*[self._fill_cpu_state_change(idx, state, res) for idx, state in cpu_states.items()])
+            return res
+
+    def save_state(self, cpu_states: Dict[int, int]):
+        if cpu_states:
+            for idx, state in cpu_states.items():
+                if idx not in self._state_cache:
+                    self._state_cache[idx] = state
+
+    @property
+    def saved_state(self) -> Dict[int, int]:
+        return {**self._state_cache}
+
+    def clear_state(self, *keys: int):
+        if keys:
+            for k in keys:
+                if k in self._state_cache:
+                    del self._state_cache[k]
+        else:
+            self._state_cache.clear()

--- a/guapow/service/optimizer/main.py
+++ b/guapow/service/optimizer/main.py
@@ -13,7 +13,7 @@ from guapow.common.dto import OptimizationRequest
 from guapow.common.log import new_logger
 from guapow.common.model_util import FileModelFiller
 from guapow.service.optimizer import win_compositor, gpu
-from guapow.service.optimizer.cpu import CPUFrequencyManager, get_cpu_count
+from guapow.service.optimizer.cpu import CPUFrequencyManager, get_cpu_count, CPUEnergyPolicyManager
 from guapow.service.optimizer.flow import OptimizationQueue
 from guapow.service.optimizer.gpu import GPUManager
 from guapow.service.optimizer.handler import OptimizationHandler
@@ -82,10 +82,12 @@ async def prepare_app() -> Tuple[web.Application, OptimizerConfig]:
 
     cpu_count = get_cpu_count()
     cpufreq_man = CPUFrequencyManager(logger=logger, cpu_count=cpu_count)
+    cpu_energy_man = CPUEnergyPolicyManager(logger=logger, cpu_count=cpu_count)
     context = OptimizationContext(cpufreq_man=cpufreq_man, gpu_man=gpu_man, logger=logger, cpu_count=cpu_count,
                                   compositor=compositor, allow_root_scripts=bool(opt_config.allow_root_scripts),
-                                  launcher_mapping_timeout=opt_config.launcher_mapping_timeout, mouse_man=MouseCursorManager(logger),
-                                  renicer_interval=opt_config.renicer_interval, queue=OptimizationQueue.empty())
+                                  launcher_mapping_timeout=opt_config.launcher_mapping_timeout,
+                                  mouse_man=MouseCursorManager(logger), renicer_interval=opt_config.renicer_interval,
+                                  cpuenergy_man=cpu_energy_man, queue=OptimizationQueue.empty())
 
     watcher_man = DeadProcessWatcherManager(context=context, restore_man=PostProcessTaskManager(context),
                                             check_interval=opt_config.check_finished_interval)

--- a/guapow/service/optimizer/post_process/context.py
+++ b/guapow/service/optimizer/post_process/context.py
@@ -18,7 +18,8 @@ class PostProcessContext:
                  restore_compositor: Optional[bool],
                  stopped_processes: Optional[List[Tuple[str, Optional[str]]]],
                  not_stopped_processes: Optional[Set[str]],
-                 restore_mouse_cursor: Optional[bool]):
+                 restore_mouse_cursor: Optional[bool],
+                 restore_cpu_energy_policy: Optional[bool]):
         self.restorable_cpus = restorable_cpus
         self.restorable_gpus = restorable_gpus
         self.pids_to_stop = pids_to_stop
@@ -29,12 +30,14 @@ class PostProcessContext:
         self.stopped_processes = stopped_processes
         self.not_stopped_processes = not_stopped_processes
         self.restore_mouse_cursor = restore_mouse_cursor
+        self.restore_cpu_energy_policy = restore_cpu_energy_policy
 
     @classmethod
     def empty(cls):
         return cls(restorable_cpus=None, restorable_gpus=None, pids_to_stop=None,
                    scripts=None, user_env=None, user_id=None, restore_compositor=None,
-                   stopped_processes=None, restore_mouse_cursor=None, not_stopped_processes=None)
+                   stopped_processes=None, restore_mouse_cursor=None, not_stopped_processes=None,
+                   restore_cpu_energy_policy=None)
 
 
 class PostContextFiller(ABC):
@@ -44,11 +47,17 @@ class PostContextFiller(ABC):
         pass
 
 
-class RestorableCPUsFiller(PostContextFiller):
+class RestorableCPUGovernorsFiller(PostContextFiller):
 
     def fill(self, context: PostProcessContext, summary: PostProcessSummary):
         if not summary.cpus_in_use and summary.previous_cpus_states:
             context.restorable_cpus = summary.previous_cpus_states
+
+
+class RestorableCPUEnergyPolicyLevelFiller(PostContextFiller):
+
+    def fill(self, context: PostProcessContext, summary: PostProcessSummary):
+        context.restore_cpu_energy_policy = not summary.keep_cpu_energy_policy and summary.restore_cpu_energy_policy
 
 
 class RestorableGPUsFiller(PostContextFiller):

--- a/guapow/service/optimizer/task/manager.py
+++ b/guapow/service/optimizer/task/manager.py
@@ -3,7 +3,7 @@ from typing import Optional, List, Awaitable, Type, Dict
 
 from guapow.service.optimizer.task.environment import EnvironmentTask, DisableWindowCompositor, \
     ChangeCPUFrequencyGovernor, ChangeGPUModeToPerformance, HideMouseCursor, StopProcessesAfterLaunch, \
-    RunPostLaunchScripts
+    RunPostLaunchScripts, ChangeCPUEnergyPolicyLevel
 from guapow.service.optimizer.task.model import OptimizationContext, Task, OptimizedProcess
 from guapow.service.optimizer.task.process import ProcessTask, ReniceProcess, ChangeCPUAffinity, \
     ChangeCPUScalingPolicy, ChangeProcessIOClass
@@ -27,7 +27,8 @@ class TasksManager:
             DisableWindowCompositor: 2,
             HideMouseCursor: 3,
             ChangeCPUFrequencyGovernor: 4,
-            ChangeGPUModeToPerformance: 5
+            ChangeCPUEnergyPolicyLevel: 5,
+            ChangeGPUModeToPerformance: 6
         }
         self._proc_order: Dict[Type[ProcessTask, int]] = {
             ReniceProcess: 0,

--- a/tests/common/config/test_optimizer_config.py
+++ b/tests/common/config/test_optimizer_config.py
@@ -189,9 +189,9 @@ class OptimizerConfigTest(TestCase):
         instance = OptimizerConfig.default()
         self.assertEqual(False, instance.allow_root_scripts)
 
-    def test_default__launcher_mapping_timeout_must_be_15_seconds(self):
+    def test_default__launcher_mapping_timeout_must_be_30_seconds(self):
         instance = OptimizerConfig.default()
-        self.assertEqual(15, instance.launcher_mapping_timeout)
+        self.assertEqual(30, instance.launcher_mapping_timeout)
 
     def test_default__check_finished_interval_must_be_3_seconds(self):
         instance = OptimizerConfig.default()

--- a/tests/common/config/test_optimizer_config_reader.py
+++ b/tests/common/config/test_optimizer_config_reader.py
@@ -25,7 +25,7 @@ class OptimizerConfigReaderTest(IsolatedAsyncioTestCase):
         self.assertFalse(config.gpu_cache)
         self.assertEqual(3, config.check_finished_interval)
         self.assertFalse(config.allow_root_scripts)
-        self.assertEqual(15, config.launcher_mapping_timeout)
+        self.assertEqual(30, config.launcher_mapping_timeout)
         self.assertIsNotNone(config.request)
         self.assertTrue(config.request.encrypted)
         self.assertIsNone(config.request.allowed_users)
@@ -96,7 +96,7 @@ class OptimizerConfigReaderTest(IsolatedAsyncioTestCase):
         file_path = f'{RESOURCES_DIR}/opt_compositor.conf'
         config = await self.reader.read_valid(file_path=file_path)
         self.assertIsNotNone(config)
-        self.assertEqual(15, config.launcher_mapping_timeout)
+        self.assertEqual(30, config.launcher_mapping_timeout)
 
     async def test_read_valid__return_instance_with_valid_launcher_mapping_timeout_defined(self):
         file_path = f'{RESOURCES_DIR}/opt_launcher_timeout.conf'

--- a/tests/service/optimizer/cpu/test_cpu_energy_policy_manager.py
+++ b/tests/service/optimizer/cpu/test_cpu_energy_policy_manager.py
@@ -1,0 +1,93 @@
+import os.path
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import Mock
+
+from guapow.service.optimizer.cpu import CPUEnergyPolicyManager
+from tests import RESOURCES_DIR
+
+TEMP_EPB_FILE_PATTERN = RESOURCES_DIR + '/cpu{idx}_ep'
+
+
+class CPUEnergyPolicyManagerTest(IsolatedAsyncioTestCase):
+
+    def tearDown(self):
+        for idx in range(2):
+            file_path = TEMP_EPB_FILE_PATTERN.format(idx=idx)
+            if os.path.exists(file_path):
+                try:
+                    os.remove(file_path)
+                except OSError:
+                    print(f"[error] could not remove file: {file_path}")
+
+    def test_can_work__false_when_no_cpus(self):
+        man = CPUEnergyPolicyManager(cpu_count=0, logger=Mock())
+        res, msg = man.can_work()
+        self.assertFalse(res)
+        self.assertIsInstance(msg, str)
+
+    def test_can_work__false_when_no_file(self):
+        man = CPUEnergyPolicyManager(cpu_count=1, logger=Mock(), file_pattern=RESOURCES_DIR + '/epb_{idx}.txt')
+        res, msg = man.can_work()
+        self.assertFalse(res)
+        self.assertIsInstance(msg, str)
+
+    def test_can_work__true_when_cpu_count_higher_than_zero_and_existing_file(self):
+        with open(TEMP_EPB_FILE_PATTERN.format(idx=0), 'w+') as f:
+            f.write('6')
+
+        man = CPUEnergyPolicyManager(cpu_count=1, logger=Mock(), file_pattern=TEMP_EPB_FILE_PATTERN)
+        res, msg = man.can_work()
+        self.assertTrue(res)
+        self.assertIsNone(msg)
+
+    async def test_map_current_state(self):
+        for idx, state in enumerate((5, 3)):
+            with open(TEMP_EPB_FILE_PATTERN.format(idx=idx), 'w+') as f:
+                f.write(str(state))
+
+        man = CPUEnergyPolicyManager(cpu_count=2, logger=Mock(), file_pattern=TEMP_EPB_FILE_PATTERN)
+        res = await man.map_current_state()
+        self.assertEqual({0: 5, 1: 3}, res)
+
+    async def test_change_states(self):
+        for idx in range(2):
+            with open(TEMP_EPB_FILE_PATTERN.format(idx=idx), 'w+') as f:
+                f.write('6')
+
+        man = CPUEnergyPolicyManager(cpu_count=2, logger=Mock(), file_pattern=TEMP_EPB_FILE_PATTERN)
+        changes = {0: 3, 1: 9}
+        res = await man.change_states(changes)
+
+        self.assertEqual({0: True, 1: True}, res)
+
+        for idx in range(2):
+            with open(TEMP_EPB_FILE_PATTERN.format(idx=idx)) as f:
+                state = f.read()
+
+            self.assertEqual(changes[idx], int(state))
+
+    def test_save_state(self):
+        man = CPUEnergyPolicyManager(cpu_count=2, logger=Mock())
+        state = {0: 4, 1: 9}
+        man.save_state(state)
+        self.assertEqual(state, man.saved_state)
+
+    def test_save_state__must_no_update_the_value_of_existing_keys(self):
+        man = CPUEnergyPolicyManager(cpu_count=2, logger=Mock())
+        man.save_state({0: 4, 1: 9})
+        man.save_state({0: 7, 1: 3, 2: 8})
+        self.assertEqual({0: 4, 1: 9, 2: 8}, man.saved_state)
+
+    def test_clear_state__must_remove_all_saved_entries_if_no_key_defined(self):
+        man = CPUEnergyPolicyManager(cpu_count=2, logger=Mock())
+        state = {0: 4, 1: 9}
+        man.save_state(state)
+        man.clear_state()
+        self.assertEqual(dict(), man.saved_state)
+
+    def test_clear_state__must_remove_defined_existing_keys(self):
+        man = CPUEnergyPolicyManager(cpu_count=2, logger=Mock())
+        state = {0: 4, 1: 9, 2: 6}
+        man.save_state(state)
+        man.clear_state(1, 3)  # 3 does not exist
+        self.assertEqual({0: 4, 2: 6}, man.saved_state)

--- a/tests/service/optimizer/optimization/test_manager.py
+++ b/tests/service/optimizer/optimization/test_manager.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 from guapow import __app_name__
 from guapow.service.optimizer.task.environment import DisableWindowCompositor, ChangeCPUFrequencyGovernor, \
-    ChangeGPUModeToPerformance, HideMouseCursor, StopProcessesAfterLaunch, RunPostLaunchScripts
+    ChangeGPUModeToPerformance, HideMouseCursor, StopProcessesAfterLaunch, RunPostLaunchScripts, ChangeCPUEnergyPolicyLevel
 from guapow.service.optimizer.task.manager import TasksManager
 from guapow.service.optimizer.task.model import OptimizationContext
 from guapow.service.optimizer.task.process import ReniceProcess, ChangeCPUAffinity, ChangeCPUScalingPolicy, \
@@ -15,6 +15,7 @@ class TasksManagerTest(IsolatedAsyncioTestCase):
     @patch(f'{__app_name__}.service.optimizer.task.environment.RunPostLaunchScripts.is_available', return_value=(True, None))
     @patch(f'{__app_name__}.service.optimizer.task.environment.HideMouseCursor.is_available', return_value=(True, None))
     @patch(f'{__app_name__}.service.optimizer.task.environment.ChangeCPUFrequencyGovernor.is_available', return_value=(True, None))
+    @patch(f'{__app_name__}.service.optimizer.task.environment.ChangeCPUEnergyPolicyLevel.is_available', return_value=(True, None))
     @patch(f'{__app_name__}.service.optimizer.task.environment.ChangeGPUModeToPerformance.is_available', return_value=(True, None))
     @patch(f'{__app_name__}.service.optimizer.task.environment.DisableWindowCompositor.is_available', return_value=(True, None))
     @patch(f'{__app_name__}.service.optimizer.task.process.ReniceProcess.is_available', return_value=(True, None))
@@ -28,13 +29,14 @@ class TasksManagerTest(IsolatedAsyncioTestCase):
         man = TasksManager(context)
         await man.check_availability()
 
-        self.assertEqual(6, len(man._env_tasks))
+        self.assertEqual(7, len(man._env_tasks))
         self.assertEqual(StopProcessesAfterLaunch, man._env_tasks[0].__class__)
         self.assertEqual(RunPostLaunchScripts, man._env_tasks[1].__class__)
         self.assertEqual(DisableWindowCompositor, man._env_tasks[2].__class__)
         self.assertEqual(HideMouseCursor, man._env_tasks[3].__class__)
         self.assertEqual(ChangeCPUFrequencyGovernor, man._env_tasks[4].__class__)
-        self.assertEqual(ChangeGPUModeToPerformance, man._env_tasks[5].__class__)
+        self.assertEqual(ChangeCPUEnergyPolicyLevel, man._env_tasks[5].__class__)
+        self.assertEqual(ChangeGPUModeToPerformance, man._env_tasks[6].__class__)
 
         self.assertEqual(4, len(man._proc_tasks))
         self.assertEqual(ReniceProcess, man._proc_tasks[0].__class__)

--- a/tests/service/optimizer/optimization/test_model.py
+++ b/tests/service/optimizer/optimization/test_model.py
@@ -4,7 +4,7 @@ from guapow.common.dto import OptimizationRequest
 from guapow.common.model import ScriptSettings
 from guapow.service.optimizer.gpu import AMDGPUDriver, GPUState, GPUPowerMode
 from guapow.service.optimizer.task.model import OptimizedProcess, CPUState
-from guapow.service.optimizer.profile import OptimizationProfile, CompositorSettings
+from guapow.service.optimizer.profile import OptimizationProfile, CompositorSettings, CPUSettings
 
 
 class OptimizedProcessTest(TestCase):
@@ -80,6 +80,10 @@ class OptimizedProcessTest(TestCase):
 
     def test_should_be_watched__true_when_processes_stopped_after_launch_are_defined(self):
         self.proc.stopped_after_launch = {'a'}
+        self.assertTrue(self.proc.should_be_watched())
+
+    def test_should_be_watched__true_when_cpu_energy_policy_changed(self):
+        self.proc.cpu_energy_policy_changed = True
         self.assertTrue(self.proc.should_be_watched())
 
     def get_display__must_return_zero_when_no_user_env_is_defined(self):


### PR DESCRIPTION
### Features
- If `cpu.performance` is defined, now the energy policy level is also set to full performance. This feature is only available for certain Intel CPUs (generally for laptop models). More on that [here](https://github.com/vinifmor/guapow/tree/cpu_epb#changing-cpu-cores-energy-policy-level-full-performance)

### Improvements
- Optimizer settings:
  - `launcher.mapping.timeout`: now defaults to `30` seconds instead of `15`