### PR TITLE
1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## NEXT
+## [1.3.1] 2022-10-22
 ### Improvements
-- optimizing the children of the target process
+- Optimizing the children of the target process
 - New optimizer service properties:
   - `optimize_children.timeout`: maximum period in *seconds* to keep looking for the target process children (default: `30`). `0` can be defined if children should be ignored.
   - `optimize_children.found_timeout`: maximum period in *seconds* to still keep looking for the target process children after a child in found (default: `10`). `0` can be defined if the search process should be interrupted immediately after a child is found.
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixes
 - Only checking for mapped processes when a process optimization is requested
+
 
 ## [1.3.0] 2022-10-15
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## NEXT
+### Fixes
+- Only checking for mapped processes when a process optimization is requested
+
 ## [1.3.0] 2022-09-15
 ### Improvements
 - Properly detecting all Steam games subprocesses that need to be optimized (no need to map launchers anymore)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## NEXT
+### Improvements
+- optimizing the children of the target process
+- New optimizer service properties:
+  - `optimize_children.timeout`: maximum period in *seconds* to keep looking for the target process children (default: `30`). `0` can be defined if children should be ignored.
+  - `optimize_children.found_timeout`: maximum period in *seconds* to still keep looking for the target process children after a child in found (default: `10`). `0` can be defined if the search process should be interrupted immediately after a child is found.
+
 ### Fixes
 - Only checking for mapped processes when a process optimization is requested
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New optimizer service properties:
   - `optimize_children.timeout`: maximum period in *seconds* to keep looking for the target process children (default: `30`). `0` can be defined if children should be ignored.
   - `optimize_children.found_timeout`: maximum period in *seconds* to still keep looking for the target process children after a child in found (default: `10`). `0` can be defined if the search process should be interrupted immediately after a child is found.
+- Ignoring some Ubisoft launcher sub-processes not required to be optimized (when launched from Steam)
 
 ### Fixes
 - Only checking for mapped processes when a process optimization is requested

--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ makepkg -si
           profile.cache = false (cache profile files on demand to skip I/O operations. Changes to profile files require restarting)
           profile.pre_caching = false (loads all existing profile files on disk in memory during the intialization process. Requires 'profile.cache' enabled)
           nice.check.interval = 5  (processes nice levels monitoring interval in seconds)  
+          optimize_children.timeout: maximum period in seconds to keep looking for the target process children (default: 30). 0 can be defined if children should be ignored.
+          optimize_children.found_timeout: maximum period in seconds to still keep looking for the target process children after a child in found (default: 10). 0 can be defined if the search process should be interrupted immediately after a child is found.
     ```
     
 - Its installation can be managed using the **guapow-cli** tool:

--- a/guapow/__init__.py
+++ b/guapow/__init__.py
@@ -2,4 +2,4 @@ import os
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 __app_name__ = 'guapow'
-__version__ = '1.3.0'
+__version__ = '1.3.1'

--- a/guapow/dist/daemon/opt.conf
+++ b/guapow/dist/daemon/opt.conf
@@ -16,3 +16,5 @@
 # profile.cache = false # cache profile files on demand to skip I/O operations. Changes to profile files require restarting
 # profile.pre_caching = false  # loads all existing profile files on disk in memory during the initialization process. Requires 'profile.cache' enabled.
 # nice.check.interval = 5  (processes nice levels monitoring interval in seconds)
+# optimize_children.timeout: maximum period in seconds to keep looking for the target process children (default: 30). 0 can be defined if children should be ignored.
+# optimize_children.found_timeout: maximum period in seconds to still keep looking for the target process children after a child in found (default: 10). 0 can be defined if the search process should be interrupted immediately after a child is found.

--- a/guapow/service/optimizer/handler.py
+++ b/guapow/service/optimizer/handler.py
@@ -2,17 +2,17 @@ import asyncio
 import os
 import time
 from asyncio import Task
-from typing import Optional, Awaitable, Tuple, Iterable, AsyncGenerator, List
+from datetime import timedelta, datetime
+from typing import Optional, Iterable, List
 
 from guapow.common.dto import OptimizationRequest
 from guapow.common.profile import get_possible_profile_paths_by_priority, \
     get_default_profile_name
+from guapow.common.system import map_processes_by_parent, find_process_children
 from guapow.service.optimizer.launcher import LauncherMapperManager
 from guapow.service.optimizer.profile import OptimizationProfile, OptimizationProfileReader
-from guapow.service.optimizer.task.environment import EnvironmentTask
 from guapow.service.optimizer.task.manager import TasksManager, run_tasks
 from guapow.service.optimizer.task.model import OptimizationContext, OptimizedProcess
-from guapow.service.optimizer.task.process import ProcessTask
 from guapow.service.optimizer.watch import DeadProcessWatcherManager
 
 
@@ -30,6 +30,13 @@ class OptimizationHandler:
         self._launcher_mapper = LauncherMapperManager(check_time=context.launcher_mapping_timeout,
                                                       found_check_time=context.launcher_mapping_found_timeout,
                                                       logger=context.logger)
+    @property
+    def children_timeout(self):
+        return self.context.search_children_timeout
+
+    @property
+    def children_found_timeout(self):
+        return self.context.search_children_found_timeout
 
     async def _read_valid_profile(self, name: str, add_settings: Optional[str], user_id: Optional[int], user_name: Optional[str], request: OptimizationRequest) -> Optional[OptimizationProfile]:
         for file_path in get_possible_profile_paths_by_priority(name=name, user_id=user_id, user_name=user_name):
@@ -68,7 +75,10 @@ class OptimizationHandler:
         self._log.warning("No optimization settings defined in configuration: {}".format(config.replace('\n', ' ')))
 
     async def _handle_process(self, process: OptimizedProcess, proc_tasks: Optional[Iterable[Task]] = None,
-                              env_tasks: Optional[Iterable[Task]] = None):
+                              env_tasks: Optional[Iterable[Task]] = None, mapped: bool = False) -> None:
+
+        await self._queue.add_pid(process.pid)
+
         if env_tasks:
             self._log.debug(f"Awaiting environment tasks required by process '{process.pid}'")
             await asyncio.gather(*run_tasks(env_tasks, process))
@@ -79,7 +89,7 @@ class OptimizationHandler:
             self._log.debug(f"Process '{process.pid}' should be watched")
             await self._watcher_man.watch(process)
 
-            if process.pid != process.source_pid:
+            if mapped:
                 await self._queue.remove_pids(process.source_pid)
 
         if proc_tasks:
@@ -100,6 +110,42 @@ class OptimizationHandler:
         self._log.debug(f"Optimization request for process '{process.pid}' took {exec_time:.4f} seconds"
                         f"{f' (source_pid={process.pid})' if request.pid != process.pid else ''}")
 
+    async def optimize_children(self, target_parents: Iterable[OptimizedProcess], env_tasks: Iterable[Task],
+                                proc_tasks: Iterable[Task]) -> None:
+        already_found = set()  # children already found
+
+        # max time period to end the iteration in case a result is found
+        latest_found_timestamp: Optional[datetime] = None
+
+        time_init = datetime.now()
+
+        # max time period to search for children
+        timeout = time_init + timedelta(seconds=self.children_timeout)
+
+        while datetime.now() < timeout:
+            if latest_found_timestamp and datetime.now() >= latest_found_timestamp:
+                ppids = ", ".join(sorted(str(p.pid) for p in target_parents))
+                self._log.debug(f"Children search timed out earlier (ppids={ppids})")
+                return
+
+            ppid_comm_pid = await map_processes_by_parent()
+
+            for parent in target_parents:
+                for pid_, comm_, ppid_ in find_process_children(ppid=parent.pid,
+                                                                processes_by_parent=ppid_comm_pid,
+                                                                already_found=already_found):
+                    if self.children_found_timeout >= 0:
+                        latest_found_timestamp = datetime.now() + timedelta(seconds=self.children_found_timeout)
+
+                    self._log.info(f"Child process found: {comm_} (pid={pid_}, ppid={ppid_})")
+                    child = parent.clone()
+                    child.pid = pid_
+                    await self._handle_process(child, proc_tasks, env_tasks)
+
+        time_end = datetime.now()
+        ppids = ", ".join(sorted(str(p.pid) for p in target_parents))
+        self._log.debug(f"Children search timed out in {(time_end - time_init).total_seconds():.2f} (ppids={ppids})")
+
     async def handle(self, request: OptimizationRequest):
         request.prepare()
 
@@ -117,9 +163,9 @@ class OptimizationHandler:
 
             source_process = OptimizedProcess(request=request, created_at=time.time(), profile=profile)
 
-            env_tasks: Optional[List[EnvironmentTask]] = None
-            proc_tasks: Optional[List[ProcessTask]] = None
-            mapped_processes = False  # if other processes were optimized in the place of the source process
+            env_tasks: Optional[Iterable[Task]] = None
+            proc_tasks: Optional[Iterable[Task]] = None
+            handled_processes: List[OptimizedProcess] = list()
 
             if profile:
                 env_tasks = await self._tasks_man.get_available_environment_tasks(source_process)
@@ -129,11 +175,20 @@ class OptimizationHandler:
 
                 async for pid in self._launcher_mapper.map_pids(source_process.request, source_process.profile):
                     if pid is not None and pid != source_process.pid:
-                        await self._queue.add_pid(pid)
-                        mapped_processes = True
                         mapped_process = source_process.clone()
                         mapped_process.pid = pid
-                        await self._handle_process(mapped_process, proc_tasks, env_tasks)
+                        await self._handle_process(mapped_process, proc_tasks, env_tasks, mapped=True)
+                        handled_processes.append(mapped_process)
 
-            if not mapped_processes:
+            if not handled_processes:
+                # if no other process was handled yet, it means the source process was not mapped as another processes.
+                # so it should be optimized
                 await self._handle_process(source_process, proc_tasks, env_tasks)
+                handled_processes.append(source_process)
+
+            if handled_processes:
+                if self.children_timeout <= 0:
+                    ppids = ", ".join(sorted(str(p.pid) for p in handled_processes))
+                    self._log.debug(f"Not looking for processes children (ppids={ppids})")
+                else:
+                    await self.optimize_children(handled_processes, proc_tasks, env_tasks)

--- a/guapow/service/optimizer/launcher.py
+++ b/guapow/service/optimizer/launcher.py
@@ -265,7 +265,9 @@ class SteamLauncherMapper(LauncherMapper):
                                "steam.exe", "python", "python3", "OriginWebHelper", "Origin.exe",
                                "OriginClientSer", "QtWebEngineProc", "EASteamProxy.ex", "ActivationUI.ex",
                                "EALink.exe", "OriginLegacyCLI", "IGOProxy.exe", "IGOProxy64.exe", "igoproxy64.exe",
-                               "ldconfig", "UPlayBrowser.exe", "whql:off", "PnkBstrA.exe"}
+                               "ldconfig", "UPlayBrowser.exe", "UbisoftGameLaun", "upc.exe", "UplayService.ex",
+                               "UplayWebCore.ex", "CrRendererMain", "regsvr32", "CrGpuMain", "CrUtilityMain",
+                               "whql:off", "PnkBstrA.exe"}
 
         return self._to_ignore
 

--- a/guapow/service/optimizer/main.py
+++ b/guapow/service/optimizer/main.py
@@ -56,6 +56,13 @@ async def prepare_app() -> Tuple[web.Application, OptimizerConfig]:
     logger.info(f'Launcher mapping timeout: {opt_config.launcher_mapping_timeout} seconds')
     logger.info(f'Launcher mapping found timeout: {opt_config.launcher_mapping_found_timeout} seconds')
 
+    logger.info(f'Children optimization timeout: {opt_config.optimize_children_timeout} seconds')
+
+    if opt_config.optimize_children_timeout <= 0:
+        logger.warning("Target processes children will not be optimized")
+
+    logger.info(f'Children optimization timeout (after found): {opt_config.optimize_children_found_timeout} seconds')
+
     if opt_config.allow_root_scripts:
         logger.warning("Scripts are allowed to run at root level")
 
@@ -98,7 +105,9 @@ async def prepare_app() -> Tuple[web.Application, OptimizerConfig]:
                                   mouse_man=MouseCursorManager(logger), renicer_interval=opt_config.renicer_interval,
                                   cpuenergy_man=cpu_energy_man, queue=OptimizationQueue(set(), logger),
                                   system_service=opt_config.is_service(),
-                                  gpu_ids={str(i) for i in opt_config.gpu_ids} if opt_config.gpu_ids else None)
+                                  gpu_ids={str(i) for i in opt_config.gpu_ids} if opt_config.gpu_ids else None,
+                                  search_children_timeout=opt_config.optimize_children_timeout,
+                                  search_children_found_timeout=opt_config.optimize_children_found_timeout)
 
     watcher_man = DeadProcessWatcherManager(context=context, restore_man=PostProcessTaskManager(context),
                                             check_interval=opt_config.check_finished_interval)

--- a/guapow/service/optimizer/task/model.py
+++ b/guapow/service/optimizer/task/model.py
@@ -18,6 +18,7 @@ class OptimizationContext:
                  cpufreq_man: Optional[CPUFrequencyManager], cpuenergy_man: Optional[CPUEnergyPolicyManager],
                  mouse_man: Optional[MouseCursorManager], queue: Optional[OptimizationQueue], cpu_count: int,
                  launcher_mapping_timeout: float, launcher_mapping_found_timeout: float, renicer_interval: float,
+                 search_children_timeout: float, search_children_found_timeout: float,
                  compositor: Optional[WindowCompositor] = None,  allow_root_scripts: bool = False,
                  compositor_disabled_context: Optional[dict] = None,
                  system_service: bool = False, gpu_ids: Optional[Set[str]] = None):
@@ -37,12 +38,14 @@ class OptimizationContext:
         self.renicer_interval = renicer_interval
         self.system_service = system_service
         self.gpu_ids = gpu_ids
+        self.search_children_timeout = search_children_timeout
+        self.search_children_found_timeout = search_children_found_timeout
 
     @classmethod
     def empty(cls) -> "OptimizationContext":
         return cls(gpu_man=None, mouse_man=None, logger=None, cpufreq_man=None, queue=None,
                    cpu_count=0, launcher_mapping_timeout=0, renicer_interval=0, cpuenergy_man=None,
-                   launcher_mapping_found_timeout=0)
+                   launcher_mapping_found_timeout=0, search_children_timeout=0, search_children_found_timeout=0)
 
     async def is_mouse_cursor_hidden(self) -> Optional[bool]:
         return await self.mouse_man.is_cursor_hidden() if self.mouse_man else None

--- a/tests/common/config/test_optimizer_config.py
+++ b/tests/common/config/test_optimizer_config.py
@@ -204,3 +204,11 @@ class OptimizerConfigTest(TestCase):
     def test_default__renicer_interval_must_be_5_seconds(self):
         instance = OptimizerConfig.default()
         self.assertEqual(5, instance.renicer_interval)
+
+    def test_default__optimize_children_timeout_must_be_30_seconds(self):
+        instance = OptimizerConfig.default()
+        self.assertEqual(30, instance.optimize_children_timeout)
+
+    def test_default__optimize_children_found_timeout_must_be_10_seconds(self):
+        instance = OptimizerConfig.default()
+        self.assertEqual(10, instance.optimize_children_found_timeout)

--- a/tests/common/config/test_optimizer_config_reader.py
+++ b/tests/common/config/test_optimizer_config_reader.py
@@ -177,3 +177,9 @@ class OptimizerConfigReaderTest(IsolatedAsyncioTestCase):
         self.assertIsNotNone(config)
         self.assertTrue(config.is_valid())
         self.assertIsNone(config.gpu_ids)
+
+    async def test_read_valid__return_instance_with_valid_optimize_children_found_timeout_defined(self):
+        file_path = f'{RESOURCES_DIR}/opt_children_found_timeout.conf'
+        config = await self.reader.read_valid(file_path=file_path)
+        self.assertIsNotNone(config)
+        self.assertEqual(0.001, config.optimize_children_found_timeout)

--- a/tests/resources/opt_children_found_timeout.conf
+++ b/tests/resources/opt_children_found_timeout.conf
@@ -1,0 +1,1 @@
+optimize_children.found_timeout=0.001

--- a/tests/resources/opt_children_timeout.conf
+++ b/tests/resources/opt_children_timeout.conf
@@ -1,0 +1,1 @@
+optimize_children.timeout=0.5

--- a/tests/service/optimizer/test_handler.py
+++ b/tests/service/optimizer/test_handler.py
@@ -9,7 +9,7 @@ from guapow.service.optimizer.handler import OptimizationHandler
 from guapow.service.optimizer.profile import OptimizationProfile, CPUSettings, OptimizationProfileReader, \
     ProcessSettings, ProcessNiceSettings
 from guapow.service.optimizer.task.model import OptimizationContext, OptimizedProcess
-from tests import RESOURCES_DIR, AsyncIterator
+from tests import RESOURCES_DIR, AsyncIterator, MockedAsyncCall
 
 
 def get_test_user_profile_path(name: str, user_name: str):
@@ -26,7 +26,7 @@ class OptimizationHandlerTest(IsolatedAsyncioTestCase):
         self.context = OptimizationContext.empty()
         self.context.logger = Mock()
         self.context.launcher_mapping_timeout = 1
-        self.request = OptimizationRequest(pid=32479274927, profile='test', command='/xpto', user_name='test')
+        self.request = OptimizationRequest(pid=1234, profile='test', command='/xpto', user_name='test')
         self.reader = OptimizationProfileReader(model_filler=FileModelFiller(Mock()), cache=None, logger=Mock())
         self.context.queue = OptimizationQueue({self.request.pid})
 
@@ -664,3 +664,283 @@ class OptimizationHandlerTest(IsolatedAsyncioTestCase):
 
         watcher_man.watch.assert_awaited_once_with(exp_source_proc)
         self.assertIn(exp_source_proc.pid, self.context.queue.get_view())
+
+    @patch('os.path.exists', return_value=True)
+    @patch(f"{__app_name__}.service.optimizer.handler.map_processes_by_parent")
+    @patch(f'{__app_name__}.service.optimizer.handler.time.time', return_value=123456789)
+    async def test_handle__must_execute_env_and_proc_tasks_for_process_children_when_no_mapping(self, *mocks: Mock):
+        time_mock, map_processes_by_parent, os_path_exists = mocks
+
+        map_processes_by_parent.return_value = {1403: {(1234, "reaper")},
+                                                1234: {(1235, "ABC.x86_")},
+                                                1235: {(1236, "ABC.x86_-thread")},
+                                                1236: {(1237, "ABC.x86_-thread-2")}}
+        tasks_man = MagicMock()
+
+        async def mock_cpu_change(proc):
+            proc.cpu_energy_policy_changed = True
+
+        env_task = AsyncMock(side_effect=mock_cpu_change)
+        tasks_man.get_available_environment_tasks = AsyncMock(return_value=[Mock(run=env_task)])
+
+        proc_task = AsyncMock()
+        tasks_man.get_available_process_tasks = AsyncMock(return_value=[Mock(run=proc_task)])
+
+        watcher_man = MagicMock()
+        watcher_man.watch = AsyncMock()
+
+        self.request.config = "cpu.performance\nproc.nice=-1"
+        self.assertIn(self.request.pid, self.context.queue.get_view())
+
+        self.context.search_children_timeout = 0.001
+        self.context.search_children_found_timeout = 0  # returns after the first iteration
+        handler = OptimizationHandler(context=self.context, tasks_man=tasks_man, watcher_man=watcher_man,
+                                      profile_reader=self.reader)
+        handler._launcher_mapper = Mock(map_pids=Mock(return_value=AsyncIterator([])))
+        await handler.handle(self.request)
+
+        exp_prof = OptimizationProfile.empty()
+        exp_prof.process = ProcessSettings(None)
+        exp_prof.process.nice.level = -1
+        exp_prof.process.io = None
+        exp_prof.process.scheduling = None
+        exp_prof.cpu = CPUSettings(performance=True)
+
+        exp_source_proc = OptimizedProcess(self.request, profile=exp_prof, created_at=123456789)
+        exp_source_proc.cpu_energy_policy_changed = True
+
+        os_path_exists.assert_called_once_with(f'/proc/{self.request.pid}')
+
+        tasks_man.get_available_process_tasks.assert_called_once_with(exp_source_proc)
+        tasks_man.get_available_environment_tasks.assert_called_once_with(exp_source_proc)
+
+        time_mock.assert_called()
+        map_processes_by_parent.assert_called_once()
+
+        exp_children = []
+
+        for pid in (1235, 1236, 1237):
+            child = exp_source_proc.clone()
+            child.pid = pid
+            exp_children.append(child)
+
+        env_task.assert_has_awaits([call(exp_source_proc), *(call(c) for c in exp_children)], any_order=True)
+        exp_source_proc.cpu_energy_policy_changed = True
+
+        proc_task.assert_has_awaits([call(exp_source_proc), *(call(c) for c in exp_children)], any_order=True)
+
+        watcher_man.watch.assert_has_awaits([call(exp_source_proc), *(call(c) for c in exp_children)], any_order=True)
+
+        optimization_queue = self.context.queue.get_view()
+        self.assertIn(exp_source_proc.pid, optimization_queue)
+
+        for child in exp_children:
+            self.assertIn(child.pid, optimization_queue)
+
+    @patch('os.path.exists', return_value=True)
+    @patch(f"{__app_name__}.service.optimizer.handler.map_processes_by_parent")
+    @patch(f'{__app_name__}.service.optimizer.handler.time.time', return_value=123456789)
+    async def test_handle__must_execute_env_and_proc_tasks_for_process_children_when_mapping(self, *mocks: Mock):
+        time_mock, map_processes_by_parent, os_path_exists = mocks
+
+        map_processes_by_parent.return_value = {1403: {(1234, "reaper")},
+                                                1234: {(1235, "ABC.exe"), (1236, "ABC.x86")},
+                                                1235: {(1237, "ABC.x86_-thread")},
+                                                1236: {(1238, "ABC.x86_-thread-2")}}
+        tasks_man = MagicMock()
+
+        async def mock_cpu_change(proc):
+            proc.cpu_energy_policy_changed = True
+
+        env_task = AsyncMock(side_effect=mock_cpu_change)
+        tasks_man.get_available_environment_tasks = AsyncMock(return_value=[Mock(run=env_task)])
+
+        proc_task = AsyncMock()
+        tasks_man.get_available_process_tasks = AsyncMock(return_value=[Mock(run=proc_task)])
+
+        watcher_man = MagicMock()
+        watcher_man.watch = AsyncMock()
+
+        self.request.config = "cpu.performance\nproc.nice=-1"
+        self.assertIn(self.request.pid, self.context.queue.get_view())
+
+        self.context.search_children_timeout = 0.001
+        self.context.search_children_found_timeout = 0  # returns after the first iteration
+        handler = OptimizationHandler(context=self.context, tasks_man=tasks_man, watcher_man=watcher_man,
+                                      profile_reader=self.reader)
+        handler._launcher_mapper = Mock(map_pids=Mock(return_value=AsyncIterator([1235, 1236])))
+        await handler.handle(self.request)
+
+        exp_prof = OptimizationProfile.empty()
+        exp_prof.process = ProcessSettings(None)
+        exp_prof.process.nice.level = -1
+        exp_prof.process.io = None
+        exp_prof.process.scheduling = None
+        exp_prof.cpu = CPUSettings(performance=True)
+
+        exp_source_proc = OptimizedProcess(self.request, profile=exp_prof, created_at=123456789)
+
+        os_path_exists.assert_called_once_with(f'/proc/{self.request.pid}')
+
+        tasks_man.get_available_process_tasks.assert_called_once_with(exp_source_proc)
+        tasks_man.get_available_environment_tasks.assert_called_once_with(exp_source_proc)
+
+        time_mock.assert_called()
+        map_processes_by_parent.assert_called_once()
+
+        exp_children = []
+
+        for pid in (1235, 1236, 1237, 1238):
+            child = exp_source_proc.clone()
+            child.pid = pid
+            child.cpu_energy_policy_changed = True
+            exp_children.append(child)
+
+        env_task.assert_has_awaits([*(call(c) for c in exp_children)], any_order=True)
+        exp_source_proc.cpu_energy_policy_changed = True
+
+        proc_task.assert_has_awaits([*(call(c) for c in exp_children)], any_order=True)
+
+        watcher_man.watch.assert_has_awaits([*(call(c) for c in exp_children)], any_order=True)
+
+        optimization_queue = self.context.queue.get_view()
+        self.assertNotIn(exp_source_proc.pid, optimization_queue)
+
+        for child in exp_children:
+            self.assertIn(child.pid, optimization_queue)
+
+    @patch('os.path.exists', return_value=True)
+    @patch(f"{__app_name__}.service.optimizer.handler.map_processes_by_parent")
+    @patch(f'{__app_name__}.service.optimizer.handler.time.time', return_value=123456789)
+    async def test_handle__must_not_optimize_children_when_timeout_less_than_or_equal_to_zero(self, *mocks: Mock):
+        time_mock, map_processes_by_parent, os_path_exists = mocks
+
+        map_processes_by_parent.return_value = {1403: {(1234, "reaper")},
+                                                1234: {(1235, "ABC.x86_")},
+                                                1235: {(1236, "ABC.x86_-thread")},
+                                                1236: {(1237, "ABC.x86_-thread-2")}}
+        tasks_man = MagicMock()
+
+        async def mock_cpu_change(proc):
+            proc.cpu_energy_policy_changed = True
+
+        env_task = AsyncMock(side_effect=mock_cpu_change)
+        tasks_man.get_available_environment_tasks = AsyncMock(return_value=[Mock(run=env_task)])
+
+        proc_task = AsyncMock()
+        tasks_man.get_available_process_tasks = AsyncMock(return_value=[Mock(run=proc_task)])
+
+        watcher_man = MagicMock()
+        watcher_man.watch = AsyncMock()
+
+        self.request.config = "cpu.performance\nproc.nice=-1"
+        self.assertIn(self.request.pid, self.context.queue.get_view())
+
+        self.context.search_children_timeout = 0
+        handler = OptimizationHandler(context=self.context, tasks_man=tasks_man, watcher_man=watcher_man,
+                                      profile_reader=self.reader)
+        handler._launcher_mapper = Mock(map_pids=Mock(return_value=AsyncIterator([])))
+        await handler.handle(self.request)
+
+        exp_prof = OptimizationProfile.empty()
+        exp_prof.process = ProcessSettings(None)
+        exp_prof.process.nice.level = -1
+        exp_prof.process.io = None
+        exp_prof.process.scheduling = None
+        exp_prof.cpu = CPUSettings(performance=True)
+
+        exp_source_proc = OptimizedProcess(self.request, profile=exp_prof, created_at=123456789)
+        exp_source_proc.cpu_energy_policy_changed = True
+
+        os_path_exists.assert_called_once_with(f'/proc/{self.request.pid}')
+
+        tasks_man.get_available_process_tasks.assert_called_once_with(exp_source_proc)
+        tasks_man.get_available_environment_tasks.assert_called_once_with(exp_source_proc)
+
+        time_mock.assert_called()
+        map_processes_by_parent.assert_not_called()
+
+        env_task.assert_called_once_with(exp_source_proc)
+        exp_source_proc.cpu_energy_policy_changed = True
+
+        proc_task.assert_called_once_with(exp_source_proc)
+
+        watcher_man.watch.assert_called_once_with(exp_source_proc)
+
+        self.assertEqual({exp_source_proc.pid},  self.context.queue.get_view())
+
+    @patch('os.path.exists', return_value=True)
+    @patch(f"{__app_name__}.service.optimizer.handler.map_processes_by_parent")
+    @patch(f'{__app_name__}.service.optimizer.handler.time.time', return_value=123456789)
+    async def test_handle__must_stop_looking_for_children_when_found_timeout_is_reached(self, *mocks: Mock):
+        time_mock, map_processes_by_parent, os_path_exists = mocks
+
+        mocked_call = MockedAsyncCall(results=[{1403: {(1234, "reaper")},
+                                                1234: {(1235, "ABC.x86_")}},
+                                               {1403: {(1234, "reaper")},
+                                                1234: {(1235, "ABC.x86_")},
+                                                1235: {(1236, "ABC.x86_-thread")}}
+                                               ],
+                                      await_time=0.001)
+        map_processes_by_parent.side_effect = mocked_call.call
+        tasks_man = MagicMock()
+
+        async def mock_cpu_change(proc):
+            proc.cpu_energy_policy_changed = True
+
+        env_task = AsyncMock(side_effect=mock_cpu_change)
+        tasks_man.get_available_environment_tasks = AsyncMock(return_value=[Mock(run=env_task)])
+
+        proc_task = AsyncMock()
+        tasks_man.get_available_process_tasks = AsyncMock(return_value=[Mock(run=proc_task)])
+
+        watcher_man = MagicMock()
+        watcher_man.watch = AsyncMock()
+
+        self.request.config = "cpu.performance\nproc.nice=-1"
+        self.assertIn(self.request.pid, self.context.queue.get_view())
+
+        self.context.search_children_timeout = 0.1
+        self.context.search_children_found_timeout = 0.01
+        handler = OptimizationHandler(context=self.context, tasks_man=tasks_man, watcher_man=watcher_man,
+                                      profile_reader=self.reader)
+        handler._launcher_mapper = Mock(map_pids=Mock(return_value=AsyncIterator([])))
+        await handler.handle(self.request)
+
+        exp_prof = OptimizationProfile.empty()
+        exp_prof.process = ProcessSettings(None)
+        exp_prof.process.nice.level = -1
+        exp_prof.process.io = None
+        exp_prof.process.scheduling = None
+        exp_prof.cpu = CPUSettings(performance=True)
+
+        exp_source_proc = OptimizedProcess(self.request, profile=exp_prof, created_at=123456789)
+        exp_source_proc.cpu_energy_policy_changed = True
+
+        os_path_exists.assert_called_once_with(f'/proc/{self.request.pid}')
+
+        tasks_man.get_available_process_tasks.assert_called_once_with(exp_source_proc)
+        tasks_man.get_available_environment_tasks.assert_called_once_with(exp_source_proc)
+
+        time_mock.assert_called()
+        self.assertGreaterEqual(map_processes_by_parent.call_count, 2)
+
+        exp_children = []
+
+        for pid in (1235, 1236):
+            child = exp_source_proc.clone()
+            child.pid = pid
+            exp_children.append(child)
+
+        env_task.assert_has_awaits([call(exp_source_proc), *(call(c) for c in exp_children)], any_order=True)
+        exp_source_proc.cpu_energy_policy_changed = True
+
+        proc_task.assert_has_awaits([call(exp_source_proc), *(call(c) for c in exp_children)], any_order=True)
+
+        watcher_man.watch.assert_has_awaits([call(exp_source_proc), *(call(c) for c in exp_children)], any_order=True)
+
+        optimization_queue = self.context.queue.get_view()
+        self.assertIn(exp_source_proc.pid, optimization_queue)
+
+        for child in exp_children:
+            self.assertIn(child.pid, optimization_queue)

--- a/tests/service/optimizer/test_launcher.py
+++ b/tests/service/optimizer/test_launcher.py
@@ -896,6 +896,11 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         expected_processes = {"whql:off"}
         self.assertTrue(expected_processes.issubset(self.mapper.to_ignore))
 
+    def test_to_ignore__must_contain_ubisoft_launcher_processes(self):
+        expected_processes = {"UPlayBrowser.exe", "UbisoftGameLaun", "upc.exe", "UplayService.ex",
+                              "UplayWebCore.ex", "CrRendererMain", "regsvr32", "CrGpuMain", "CrUtilityMain"}
+        self.assertTrue(expected_processes.issubset(self.mapper.to_ignore))
+
 
 class ProcessLauncherManagerTest(IsolatedAsyncioTestCase):
 

--- a/tests/service/optimizer/test_launcher.py
+++ b/tests/service/optimizer/test_launcher.py
@@ -348,7 +348,7 @@ class ExplicitLauncherMapperTest(IsolatedAsyncioTestCase):
 
         mocked_call = MockedAsyncCall(results=[(0, "456# game_x86_64.bin\n789# other\n"),
                                                (0, "456# game_x86_64.bin\n789# other\n1011# game_x86_64.bin")],
-                                      await_time=0.0005)
+                                      await_time=0.001)
         async_syscall.side_effect = mocked_call.call
 
         map_launchers.return_value = {"game": ("game_x86_64.bin", LauncherSearchMode.NAME)}
@@ -356,7 +356,7 @@ class ExplicitLauncherMapperTest(IsolatedAsyncioTestCase):
         request = OptimizationRequest(pid=123, command='/usr/local/bin/game', user_name='user')
         profile = new_steam_profile(enabled=False)
 
-        self.mapper = ExplicitLauncherMapper(check_time=0.01, found_check_time=-1, iteration_sleep_time=0,
+        self.mapper = ExplicitLauncherMapper(check_time=0.1, found_check_time=-1, iteration_sleep_time=0,
                                              logger=self.logger)
 
         async def map_pids() -> Set[int]:
@@ -385,7 +385,7 @@ class ExplicitLauncherMapperTest(IsolatedAsyncioTestCase):
         profile = new_steam_profile(enabled=False)
 
         # setting 'found_check_time' to zero, so the next iteration wouldn't happen
-        self.mapper = ExplicitLauncherMapper(check_time=0.1, found_check_time=0, iteration_sleep_time=0,
+        self.mapper = ExplicitLauncherMapper(check_time=1, found_check_time=0, iteration_sleep_time=0,
                                              logger=self.logger)
 
         async def map_pids() -> Set[int]:
@@ -404,7 +404,7 @@ class ExplicitLauncherMapperTest(IsolatedAsyncioTestCase):
 class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
 
     def setUp(self):
-        self.mapper = SteamLauncherMapper(check_time=0.0001, found_check_time=0.0001, iteration_sleep_time=0,
+        self.mapper = SteamLauncherMapper(check_time=0.1, found_check_time=0, iteration_sleep_time=0,
                                           logger=Mock())
 
     @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """

--- a/tests/service/optimizer/test_launcher.py
+++ b/tests/service/optimizer/test_launcher.py
@@ -407,7 +407,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.mapper = SteamLauncherMapper(check_time=0.0001, found_check_time=0.0001, iteration_sleep_time=0,
                                           logger=Mock())
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall", return_value=(0, """
+    @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """
             1403#    2601# reaper
             2601#    2602# ABC.x86_
             2601#    2603# ABC.x86_-thread
@@ -428,7 +428,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(async_syscall.await_count, 1)
         self.assertEqual({2602, 2603}, mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall", return_value=(0, """
+    @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """
        1403#    11573# reaper
        11573#   11574# pv-bwrap
        11574#   11728# pressure-vessel
@@ -454,7 +454,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(async_syscall.await_count, 1)
         self.assertEqual({13786, 13787}, mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall", return_value=(0, """
+    @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """
         1435#    5614# reaper
         5614#    5615# python3
         5615#    5661# Game_x64.exe
@@ -476,7 +476,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(async_syscall.await_count, 1)
         self.assertEqual({5661, 5662}, mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall")
+    @patch(f"{__app_name__}.common.system.async_syscall")
     async def test_map_pids__yield_several_ids_when_proton_command_from_runtime(self, async_syscall: AsyncMock):
         mocked_call = MockedAsyncCall(results=[(0, """12# 123#  reaper
                                                       123# 456#  pv-bwrap
@@ -512,7 +512,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(async_syscall.await_count, 2)
         self.assertEqual({1213, 1214}, mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall", return_value=(0, """
+    @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """
         1435#    5614# reaper
         5614#    30324# pv-bwrap
         30324#   30408# pressure-vessel
@@ -556,7 +556,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(async_syscall.await_count, 1)
         self.assertEqual({5661}, mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall", return_value=(0, """
+    @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """
         1435#    5614# reaper
         5614#    30324# pv-bwrap
         30324#   30408# pressure-vessel
@@ -584,7 +584,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(async_syscall.await_count, 1)
         self.assertEqual({5661}, mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall", return_value=(0, """
+    @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """
         1435#    5614# reaper
         5614#    30324# pv-bwrap
         30324#   30408# pressure-vessel
@@ -609,7 +609,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(async_syscall.await_count, 1)
         self.assertEqual({5661}, mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall", return_value=(0, """
+    @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """
         1435#    5614# reaper
         5614#    30324# pv-bwrap
         30324#   30408# pressure-vessel
@@ -636,7 +636,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(async_syscall.await_count, 1)
         self.assertEqual({5661}, mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall", return_value=(0, """
+    @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """
         1435#    5614# reaper
         5614#    30324# pv-bwrap
         30324#   30408# pressure-vessel
@@ -663,7 +663,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(async_syscall.await_count, 1)
         self.assertEqual({5661}, mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall", return_value=(0, """
+    @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """
         12# 123#  reaper
         123# 456#  pv-bwrap
         456# 789#  pressure-vessel
@@ -689,7 +689,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(async_syscall.await_count, 1)
         self.assertEqual({1213, 1214}, mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall", return_value=(0, """
+    @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """
         12# 123#  reaper
         123# 456#  pv-bwrap
         456# 789#  pressure-vessel
@@ -713,7 +713,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(async_syscall.await_count, 1)
         self.assertEqual(set(), mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall")
+    @patch(f"{__app_name__}.common.system.async_syscall")
     async def test_map_pids__it_should_stopping_yielding_if_found_check_time_reached(self, *mocks: AsyncMock):
         async_syscall = mocks[0]
 
@@ -738,13 +738,13 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         self.assertEqual(1, async_syscall.await_count)
         self.assertEqual({2602}, mapped_pids)
 
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall", return_value=(0, """
+    @patch(f"{__app_name__}.common.system.async_syscall", return_value=(0, """
             1403#    2601# reaper
             2601#    2602# ABC.x86_
             2602#    2603# ABC.x86_-thread
             2603#    2604# ABC.x86_-thread-2
     """))
-    async def test_map_pids__it_should_yield_children_of_target_children(self, async_syscall: AsyncMock):
+    async def test_map_pids__it_should_not_yield_children_of_target_children(self, async_syscall: AsyncMock):
         cmd = "/home/user/.local/share/Steam/ubuntu12_32/reaper SteamLaunch AppId=999999 -- " \
               "/home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper -- " \
               "/media/hd0/Steam/steamapps/common/Game/ABC.x86_"
@@ -758,7 +758,7 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
         mapped_pids = await map_pids()
         async_syscall.assert_awaited_with(f'ps -Ao "%P#%p#%c" -ww --no-headers')
         self.assertGreaterEqual(async_syscall.await_count, 1)
-        self.assertEqual({2602, 2603, 2604}, mapped_pids)
+        self.assertEqual({2602}, mapped_pids)
 
     def test_map_expected_hierarchy__when_proton_command(self):
         cmd = "/home/user/.local/share/Steam/ubuntu12_32/reaper SteamLaunch AppId=443860 -- " \
@@ -811,28 +811,6 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
 
         root_cmd = self.mapper.extract_root_process_name(cmd)
         self.assertEqual("reaper", root_cmd)
-
-    @patch(f"{__app_name__}.service.optimizer.launcher.async_syscall")
-    async def test_map_processes_by_parent(self, async_syscall: AsyncMock):
-        async_syscall.return_value = (0, """
-        1411#    5202# reaper
-        5202#    5203# pv-bwrap
-        5203#    5286# pressure-vessel
-        5286#    7925# python3
-        5286#    8017# wineserver
-        5286#    8708# Game.exe
-        5286#    8747# Game-Win64-Shi
-        """)
-
-        proc_map = await self.mapper.map_processes_by_parent()
-        async_syscall.assert_awaited_with(f'ps -Ao "%P#%p#%c" -ww --no-headers')
-        self.assertEqual(4, len(proc_map))
-
-        expected = {1411: {(5202, "reaper")},
-                    5202: {(5203, "pv-bwrap")},
-                    5203: {(5286, "pressure-vessel")},
-                    5286: {(7925, "python3"), (8017, "wineserver"), (8708, "Game.exe"), (8747, "Game-Win64-Shi")}}
-        self.assertEqual(expected, proc_map)
 
     def test_find_target_in_hierarchy__return_the_root_id_when_just_one_element_hierarchy(self):
         hierarchy = ["reaper"]
@@ -917,19 +895,6 @@ class SteamLauncherMapperTest(IsolatedAsyncioTestCase):
     def test_to_ignore__must_contain_unknown_unneeded_processes(self):
         expected_processes = {"whql:off"}
         self.assertTrue(expected_processes.issubset(self.mapper.to_ignore))
-
-    def test_find_children__it_should_find_children_of_already_found_processes(self):
-        parent_procs = {
-            123: {(456, "reaper")},
-            456: {(789, "pv-bwrap")},
-            789: {(1011, "abc"), (1012, "def")}
-        }
-
-        already_found = {789}
-        new_found = {p for p in self.mapper.find_children(ppid=456,
-                                                          processes_by_parent=parent_procs,
-                                                          already_found=already_found)}
-        self.assertEqual({1011, 1012}, new_found)
 
 
 class ProcessLauncherManagerTest(IsolatedAsyncioTestCase):


### PR DESCRIPTION
### Improvements
- Optimizing the children of the target process
- New optimizer service properties:
  - `optimize_children.timeout`: maximum period in *seconds* to keep looking for the target process children (default: `30`). `0` can be defined if children should be ignored.
  - `optimize_children.found_timeout`: maximum period in *seconds* to still keep looking for the target process children after a child in found (default: `10`). `0` can be defined if the search process should be interrupted immediately after a child is found.
- Ignoring some Ubisoft launcher sub-processes not required to be optimized (when launched from Steam)

### Fixes
- Only checking for mapped processes when a process optimization is requested