### PR TITLE
1.3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv
 env
 venv
 *.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [NEXT]
 ### Improvements
 - do not try to disable window compositors for wayland sessions
+- do not try to hide the mouse pointer when `mouse.hidden` is requested for wayland sessions (`unclutter` does not support wayland at the moment)
 
 ## [1.3.3] 2023-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [NEXT]
 ### Improvements
-- do not try to disable window compositors for wayland sessions
+- do not try to disable window compositors when `compositor.off` if requested for wayland sessions
 - do not try to hide the mouse pointer when `mouse.hidden` is requested for wayland sessions (`unclutter` does not support wayland at the moment)
 
 ## [1.3.3] 2023-08-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [NEXT]
+### Improvements
+- do not try to disable window compositors for wayland sessions
+
 ## [1.3.3] 2023-08-12
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [NEXT]
+## [1.3.4] 2024-01-16
 ### Improvements
-- do not try to disable window compositors when `compositor.off` if requested for wayland sessions
-- do not try to hide the mouse pointer when `mouse.hidden` is requested for wayland sessions (`unclutter` does not support wayland at the moment)
+- do not try to disable window compositors when `compositor.off` if requested from a wayland session
+- do not try to hide the mouse pointer when `mouse.hidden` is requested from a wayland session (`unclutter` does not support wayland at the moment)
 - adding a new project definition/setup (`pyproject.toml`) file to comply with the latest standards
 
 ## [1.3.3] 2023-08-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Improvements
 - do not try to disable window compositors when `compositor.off` if requested for wayland sessions
 - do not try to hide the mouse pointer when `mouse.hidden` is requested for wayland sessions (`unclutter` does not support wayland at the moment)
+- adding a new project definition/setup (`pyproject.toml`) file to comply with the latest standards
 
 ## [1.3.3] 2023-08-12
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,9 @@
-include LICENSE CHANGELOG.md README.md
-include requirements.txt
+include LICENSE CHANGELOG.md README.md requirements.txt
+exclude launchers
+exclude guapow.egg-info
+exclude .pytest_cache
+exclude py_dist.sh
 recursive-include guapow/dist *
+recursive-exclude guapow/dist *.orig
+recursive-exclude venv *
+recursive-exclude .venv *

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ makepkg -si
 - Some applications do not hide the mouse pointer by default, and can spoil the user experience.
 - Property definition: 
     - `mouse.hidden` (equivalents: `mouse.hidden=true` or `mouse.hidden=1`)
-- Requires **unclutter** installed.
+- Requires **unclutter** installed (**it does not support wayland at the moment**)
 - The mouse pointer will be hidden after the target application starts.
 - The **optimizer** service will keep the mouse pointer hidden until the optimized application finishes. It handles the state if two or more optimized applications require `mouse.hidden`. So if application A and B require `mouse.hidden` and A finishes after a while, the pointer will be kept hidden until B finishes.
     

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ makepkg -si
  #### <a name="opt_compositor">Disabling window compositor</a>
  - Window compositors are responsible for managing the window/desktop effects, and prevent visual glitches (like screen tearing). They generally come pre-bundled with desktop environments, window managers and distributions.
  - Some applications perform better when the compositor is disabled (e.g: games)
+ - Not supported for wayland sessions
  - Currently supported compositors: 
     - **kwin** (KDE desktop environment)
     - **xfwm4** (XFCE desktop environment)

--- a/guapow/__init__.py
+++ b/guapow/__init__.py
@@ -2,4 +2,4 @@ import os
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 __app_name__ = 'guapow'
-__version__ = '1.3.3'
+__version__ = '1.3.4'

--- a/guapow/common/dto.py
+++ b/guapow/common/dto.py
@@ -11,7 +11,7 @@ class OptimizationRequest:
     def __init__(self, pid: Optional[int], command: Optional[str], user_name: Optional[str], profile: Optional[str] = None,
                  created_at: Optional[float] = time.time(), config: Optional[str] = None,
                  profile_config: Optional[str] = None, related_pids: Optional[Set[int]] = None,
-                 user_env: Optional[dict] = None, stopped_processes: Optional[Dict[str, Optional[str]]] = None,
+                 user_env: Optional[Dict[str, str]] = None, stopped_processes: Optional[Dict[str, Optional[str]]] = None,
                  relaunch_stopped_processes: Optional[bool] = None):
         self.pid = pid
         self.command = command

--- a/guapow/common/util.py
+++ b/guapow/common/util.py
@@ -1,6 +1,7 @@
+import os
 import re
 from re import Pattern
-from typing import Optional
+from typing import Optional, Dict
 
 re_any_operator = re.compile(r'\*+')
 
@@ -26,3 +27,6 @@ def strip_file_extension(cmd: str) -> Optional[str]:
     if cmd:
         return '.'.join(cmd.split('.')[0:-1])
 
+
+def is_wayland_session(envvars: Dict[str, str] = os.environ):
+    return envvars and envvars.get("XDG_SESSION_TYPE", "").lower() == "wayland"

--- a/guapow/service/optimizer/task/environment.py
+++ b/guapow/service/optimizer/task/environment.py
@@ -1,7 +1,7 @@
 import os
 from abc import ABC
 from asyncio import Lock
-from typing import Optional, Tuple, List
+from typing import Optional, Tuple, List, Dict
 
 from guapow.common.scripts import RunScripts
 from guapow.common.users import is_root_user
@@ -112,6 +112,10 @@ class DisableWindowCompositor(EnvironmentTask):
         self._manageable: Optional[bool] = None
         self._lock = Lock()
 
+    @staticmethod
+    def is_wayland_session(env: Dict[str, str] = os.environ):
+        return env and env.get("XDG_SESSION_TYPE", "").lower() == "wayland"
+
     async def is_available(self) -> Tuple[bool, Optional[str]]:
         return True, None
 
@@ -119,6 +123,10 @@ class DisableWindowCompositor(EnvironmentTask):
         request, profile = process.request, process.profile
 
         if profile.compositor and profile.compositor.off:
+            if self.is_wayland_session(process.request.user_env):
+                self._log.info("wayland session request: compositor will not be disabled")
+                return False
+
             async with self._lock:
                 if not self._context.compositor and not self._compositor_checked:
                     compositor = await get_window_compositor(logger=self._log, user_id=request.user_id, user_env=request.user_env)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "guapow"
+description = "On-demand and auto performance optimizer for Linux applications"
+license = {file = "LICENSE"}
+requires-python = ">=3.8"
+dynamic = ["version"]
+readme = "README.md"
+authors = [{name = "Vinicius Moreira", email = "vinicius_fmoreira@hotmail.com"}]
+classifiers = [
+        'Topic :: Utilities',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11'
+]
+
+dependencies = [
+    "aiofiles >= 0.7.0",
+    "aiohttp >= 3.7.0",
+    "pycryptodome >= 3.10.1",
+]
+
+[project.scripts]
+guapow = "guapow.runner.main:run"
+guapow-cli = "guapow.cli.main:run"
+guapow-opt = "guapow.service.optimizer.main:start"
+guapow-watch = "guapow.service.watcher.main:start"
+
+[project.urls]
+Repository = "https://github.com/vinifmor/guapow"
+
+[tool.setuptools]
+license-files = ["LICENSE"]
+
+[tool.setuptools.dynamic]
+version = {attr = "guapow.__version__"}
+
+[tool.setuptools.packages.find]
+exclude = ["tests.*", "tests"]

--- a/tests/service/optimizer/optimization/test_environment.py
+++ b/tests/service/optimizer/optimization/test_environment.py
@@ -451,7 +451,7 @@ class HideMouseCursorTest(IsolatedAsyncioTestCase):
     def setUp(self):
         self.context = OptimizationContext.empty()
         self.context.mouse_man = Mock()
-        self.context.logger = Mock()
+        self.context.logger = MagicMock()
 
         self.task = HideMouseCursor(self.context)
         self.profile = OptimizationProfile.empty('test')
@@ -469,6 +469,12 @@ class HideMouseCursorTest(IsolatedAsyncioTestCase):
     async def test_should_run__true_when_hide_mouse_is_set_to_true(self):
         self.profile.hide_mouse = True
         self.assertTrue(await self.task.should_run(self.process))
+
+    async def test_should_run__false_when_wayland_session(self):
+        self.profile.hide_mouse = True
+        self.process.request.user_env = {"XDG_SESSION_TYPE": "WaylanD"}
+        self.assertFalse(await self.task.should_run(self.process))
+        self.context.logger.info.assert_called_once_with("wayland session request: mouse hidden is not supported")
 
     async def test_should_run__false_when_hide_mouse_is_not_defined(self):
         self.profile.hide_mouse = None


### PR DESCRIPTION
### Improvements
- do not try to disable window compositors when `compositor.off` if requested from a wayland session
- do not try to hide the mouse pointer when `mouse.hidden` is requested from a wayland session (`unclutter` does not support wayland at the moment)
- adding a new project definition/setup (`pyproject.toml`) file to comply with the latest standards