### PR TITLE
1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [NEXT]
+## [1.3.5]
 ### Improvements
 - Only GPUs connected to a display device will be considered for optimizations by default
   - this behavior is controlled by the new optimizer service configuration property `gpu.only_connected`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.3.5]
+## [1.3.5] 2025-03-25
 ### Improvements
 - Only GPUs connected to a display device will be considered for optimizations by default
   - this behavior is controlled by the new optimizer service configuration property `gpu.only_connected`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [NEXT]
+### Improvements
+- Only GPUs connected to a display device will be considered for optimizations by default
+  - this behavior is controlled by the new optimizer service configuration property `gpu.only_connected`
+  - this behavior is only implemented for AMD GPUs at the moment
+
 ## [1.3.4] 2024-01-16
 ### Improvements
 - do not try to disable window compositors when `compositor.off` if requested from a wayland session

--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ makepkg -si
           launcher.mapping.found_timeout = 10 (maximum time in seconds to still keep looking for a process mapped to a different process after a match. This property also affects the period to look for Steam subprocesses.  float values are allowed)
           gpu.cache = false (if 'true': maps all available GPUs once after the first request (if running as a system service) or during startup (if not running as system service). Otherwise, GPUs will be mapped for every request)
           gpu.id = # comma separated list of integers representing which GPU cards should be optimized (e.g: 0, 1). If not defined, all available GPUs are considered (default)
+          gpu.only_connected = true  # only GPUs connected to a display device will be considered for optimizations (AMD only)
           gpu.vendor =  # pre-defines your GPU vendor for faster GPUs mapping. Supported: nvidia, amd
           cpu.performance = false  (set cpu governors and energy policy levels to full performance on startup)
           request.allowed_users = (restricts users that can request optimizations, separated by comma. e.g: root,xpto)

--- a/guapow/__init__.py
+++ b/guapow/__init__.py
@@ -2,4 +2,4 @@ import os
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 __app_name__ = 'guapow'
-__version__ = '1.3.4'
+__version__ = '1.3.5'

--- a/guapow/common/config.py
+++ b/guapow/common/config.py
@@ -79,6 +79,7 @@ class OptimizerConfig(RootFileModel):
                     'gpu.cache': ('gpu_cache', bool, True),
                     'gpu.id': ('gpu_ids', Set[int], None),
                     'gpu.vendor': ('gpu_vendor', str, None),
+                    'gpu.only_connected': ('gpu_only_connected', bool, True),
                     'cpu.performance': ('cpu_performance', bool, True),
                     'profile.cache': ('profile_cache', bool, True),
                     'profile.pre_caching': ('pre_cache_profiles', bool, True),
@@ -94,7 +95,8 @@ class OptimizerConfig(RootFileModel):
                  pre_cache_profiles: Optional[bool] = None, gpu_vendor: Optional[str] = None,
                  renicer_interval: Optional[float] = None, gpu_ids: Optional[Set[int]] = None,
                  optimize_children_timeout: Optional[float] = 30,
-                 optimize_children_found_timeout: Optional[float] = 10):
+                 optimize_children_found_timeout: Optional[float] = 10,
+                 gpu_only_connected: Optional[bool] = True):
         self.port = port
         self.compositor = compositor
         self.allow_root_scripts = allow_root_scripts
@@ -104,6 +106,7 @@ class OptimizerConfig(RootFileModel):
         self.gpu_cache = gpu_cache
         self.gpu_vendor = gpu_vendor
         self.gpu_ids = gpu_ids
+        self.gpu_only_connected = gpu_only_connected
         self.cpu_performance = cpu_performance
         self.request = RequestSettings.default()
         self.profile_cache = profile_cache
@@ -182,6 +185,9 @@ class OptimizerConfig(RootFileModel):
 
         if self.gpu_cache is None:
             self.gpu_cache = False
+
+        if self.gpu_only_connected is None:
+            self.gpu_only_connected = True
 
         if self.profile_cache is None:
             self.profile_cache = False

--- a/guapow/dist/daemon/opt.conf
+++ b/guapow/dist/daemon/opt.conf
@@ -9,6 +9,7 @@
 # launcher.mapping.found_timeout = 10 (maximum time in seconds to still keep looking for a process mapped to a different process after a match. This property also affects the period to look for Steam subprocesses.  float values are allowed)
 # gpu.cache = false # if 'true': maps all available GPUs on startup. Otherwise, GPUs will be mapped for every request
 # gpu.id = # comma separated list of integers representing which GPU cards should be optimized (e.g: 0, 1). If not defined, all available GPUs are considered (default)
+# gpu.only_connected = true  # only GPUs connected to a display device will be considered for optimizations (AMD only)
 # gpu.vendor =  # pre-defines your GPU vendor for faster GPUs mapping. Supported: nvidia, amd
 # cpu.performance = false  # set cpu governors and energy policy levels to full performance on startup
 # request.allowed_users =  # restricts users that can request optimizations, separated by comma. e.g: root,xpto)

--- a/guapow/service/optimizer/main.py
+++ b/guapow/service/optimizer/main.py
@@ -83,7 +83,9 @@ async def prepare_app() -> Tuple[web.Application, OptimizerConfig]:
 
         if gpu_driver:
             logger.info(f'Pre-defined GPU vendor: {opt_config.gpu_vendor}')
-            gpu_drivers = (gpu_driver(cache=opt_config.gpu_cache, logger=logger),)
+            gpu_drivers = (gpu_driver(cache=opt_config.gpu_cache,
+                                      only_connected=opt_config.gpu_only_connected,
+                                      logger=logger),)
         else:
             logger.warning(f'Invalid pre-defined GPU vendor: {opt_config.gpu_vendor}')
 
@@ -93,8 +95,8 @@ async def prepare_app() -> Tuple[web.Application, OptimizerConfig]:
     if not opt_config.gpu_cache:
         logger.warning("Available GPUs cache is disabled. Available GPUs will be mapped for every request")
 
-    gpu_man = GPUManager(cache_gpus=opt_config.gpu_cache, logger=logger, drivers=gpu_drivers)
-
+    gpu_man = GPUManager(cache_gpus=opt_config.gpu_cache, only_connected=opt_config.gpu_only_connected,
+                         logger=logger, drivers=gpu_drivers)
     cpu_count = get_cpu_count()
     cpufreq_man = CPUFrequencyManager(logger=logger, cpu_count=cpu_count)
     cpu_energy_man = CPUEnergyPolicyManager(logger=logger, cpu_count=cpu_count)

--- a/tests/common/config/test_optimizer_config.py
+++ b/tests/common/config/test_optimizer_config.py
@@ -178,12 +178,21 @@ class OptimizerConfigTest(TestCase):
         config.launcher_mapping_timeout = 0
         self.assertFalse(config.is_valid())
 
+    def test_is_valid__true_when_gpu_only_connected_is_bool(self):
+        config = OptimizerConfig.default()
+        config.gpu_only_connected = False
+        self.assertTrue(config.is_valid())
+
     def test_default__must_be_valid(self):
         self.assertTrue(OptimizerConfig.default().is_valid())
 
     def test_default__gpu_cache_must_be_false(self):
         instance = OptimizerConfig.default()
         self.assertEqual(False, instance.gpu_cache)
+
+    def test_default__gpu_only_connected_must_be_true(self):
+        instance = OptimizerConfig.default()
+        self.assertEqual(True, instance.gpu_only_connected)
 
     def test_default__allow_root_scripts_must_be_false(self):
         instance = OptimizerConfig.default()

--- a/tests/resources/amd/gpu/card0-HDMI-1/status
+++ b/tests/resources/amd/gpu/card0-HDMI-1/status
@@ -1,0 +1,1 @@
+disconnected

--- a/tests/resources/amd/gpu/card1-HDMI-2/status
+++ b/tests/resources/amd/gpu/card1-HDMI-2/status
@@ -1,0 +1,1 @@
+connected

--- a/tests/resources/amd/gpu/card4-DP-1/status
+++ b/tests/resources/amd/gpu/card4-DP-1/status
@@ -1,0 +1,1 @@
+connected

--- a/tests/resources/amd/gpu/card4-DP-2/status
+++ b/tests/resources/amd/gpu/card4-DP-2/status
@@ -1,0 +1,1 @@
+disconnected

--- a/tests/service/optimizer/gpu/test_amd_gpu_driver.py
+++ b/tests/service/optimizer/gpu/test_amd_gpu_driver.py
@@ -4,23 +4,21 @@ import shutil
 import sys
 import traceback
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, patch, AsyncMock
 
 from guapow.service.optimizer.gpu import AMDGPUDriver
 from tests import RESOURCES_DIR
 
-TEST_GPU_FOLDER = RESOURCES_DIR + '/amd/gpu/card{id}/device'
+TEST_GPU_FOLDER = RESOURCES_DIR + '/amd/gpu/card{id}'
 TEMP_GPU_FOLDER = TEST_GPU_FOLDER.format(id=5)
 
 
 class AMDGPUDriverTest(IsolatedAsyncioTestCase):
 
     def tearDown(self):
-        temp_dir = os.path.dirname(TEMP_GPU_FOLDER)
-
-        if os.path.exists(temp_dir):
+        if os.path.exists(TEMP_GPU_FOLDER):
             try:
-                shutil.rmtree(temp_dir)
+                shutil.rmtree(TEMP_GPU_FOLDER)
             except:
                 sys.stderr.write(f"Could not remove temp AMD gpu folder '{TEMP_GPU_FOLDER}'")
                 traceback.print_exc()
@@ -29,33 +27,50 @@ class AMDGPUDriverTest(IsolatedAsyncioTestCase):
         self.assertEqual('AMD', AMDGPUDriver.get_vendor_name())
 
     async def test_can_work__always_true(self):
-        driver = AMDGPUDriver(cache=False, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
+        driver = AMDGPUDriver(cache=False, only_connected=False, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
         res, msg = driver.can_work()
         self.assertTrue(res)
         self.assertIsNone(msg)
 
     def test_get_default_mode__must_return_auto_and_3(self):
-        driver = AMDGPUDriver(cache=False, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
+        driver = AMDGPUDriver(cache=False, only_connected=False,  logger=Mock(), gpus_path=TEST_GPU_FOLDER)
         self.assertEqual('auto:3', driver.get_default_mode())
 
     def test_get_performance_mode__must_return_manual_and_5(self):
-        driver = AMDGPUDriver(cache=False, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
+        driver = AMDGPUDriver(cache=False, only_connected=False, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
         self.assertEqual('manual:5', driver.get_performance_mode())
 
     async def test_get_gpus__empty_when_there_are_no_files(self):
-        driver = AMDGPUDriver(cache=False, logger=Mock(), gpus_path=RESOURCES_DIR)
+        driver = AMDGPUDriver(cache=False, only_connected=False, logger=Mock(), gpus_path=RESOURCES_DIR)
         returned = await driver.get_gpus()
         self.assertIsNone(returned)
 
     async def test_get_gpus__return_available_gpus_when_required_files_exist(self):
-        driver = AMDGPUDriver(cache=False, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
+        driver = AMDGPUDriver(cache=False, only_connected=False, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
         returned = await driver.get_gpus()
         self.assertIsNotNone(returned)
 
         self.assertEqual({'1', '2', '3', '4'}, returned)
 
+    async def test_get_gpus__return_only_connected_gpus_when_required_files_exist(self):
+        driver = AMDGPUDriver(cache=False, only_connected=True, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
+        returned = await driver.get_gpus()
+        self.assertIsNotNone(returned)
+
+        self.assertEqual({'1', '4'}, returned)
+
+    @patch("guapow.service.optimizer.gpu.AMDGPUDriver.get_connected_gpus", return_value=set())
+    async def test_get_gpus__return_none_if_no_available_gpu_connected_even_if_required_files_exist(self, *mocks: Mock):
+        driver = AMDGPUDriver(cache=False, only_connected=True, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
+        returned = await driver.get_gpus()
+
+        get_connected_gpus: AsyncMock = mocks[0]
+        get_connected_gpus.assert_awaited_once()
+
+        self.assertIsNone(returned)
+
     async def test_get_power_mode__return_a_string_concatenating_the_performance_and_profile_ids(self):
-        driver = AMDGPUDriver(cache=False, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
+        driver = AMDGPUDriver(cache=False, only_connected=False, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
 
         gpu_ids = {str(n) for n in range(1, 5)}
         actual_modes = await driver.get_power_mode(gpu_ids)
@@ -75,18 +90,18 @@ class AMDGPUDriverTest(IsolatedAsyncioTestCase):
         except:
             self.fail(f"Could not copy example folder '{example_folder}'")
 
-        driver = AMDGPUDriver(cache=False, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
-        card_id = re.compile(r'/card(\d+)/device$').findall(TEMP_GPU_FOLDER)[0]
+        driver = AMDGPUDriver(cache=False, only_connected=False, logger=Mock(), gpus_path=TEST_GPU_FOLDER)
+        card_id = re.compile(r'/card(\d+)$').findall(TEMP_GPU_FOLDER)[0]
 
         res = await driver.set_power_mode({card_id: driver.get_performance_mode()})
         self.assertEqual({card_id: True}, res)
 
-        with open(f'{TEMP_GPU_FOLDER}/{AMDGPUDriver.PERFORMANCE_FILE}') as f:
+        with open(f'{TEMP_GPU_FOLDER}/device/{AMDGPUDriver.PERFORMANCE_FILE}') as f:
             control_mode = f.read()
 
         self.assertEqual('manual', control_mode)
 
-        with open(f'{TEMP_GPU_FOLDER}/{AMDGPUDriver.PROFILE_FILE}') as f:
+        with open(f'{TEMP_GPU_FOLDER}/device/{AMDGPUDriver.PROFILE_FILE}') as f:
             power_mode = f.read()
 
         self.assertEqual('5', power_mode)

--- a/tests/service/optimizer/gpu/test_gpu_manager.py
+++ b/tests/service/optimizer/gpu/test_gpu_manager.py
@@ -63,11 +63,11 @@ class GPUManagerTest(IsolatedAsyncioTestCase):
         driver_2.get_cached_gpus.assert_called_once()
 
     async def test_map_working_drivers_and_gpus__must_lock_concurrent_requests_when_cache_is_on(self):
-        driver_1 = AMDGPUDriver(cache=True, logger=Mock())
+        driver_1 = AMDGPUDriver(cache=True, only_connected=False, logger=Mock())
         driver_1.can_work = Mock(return_value=(True, None))
         driver_1.get_gpus = AsyncMock(return_value={'0'})
 
-        man = GPUManager(Mock(), drivers=(driver_1,), cache_gpus=True)
+        man = GPUManager(Mock(), drivers=(driver_1,), cache_gpus=True, only_connected=False)
         self.assertIsNone(man.get_cached_working_drivers())
 
         async def mock_map_working_drivers() -> List[Tuple[GPUDriver, Set[str]]]:


### PR DESCRIPTION
### Improvements
- Only GPUs connected to a display device will be considered for optimizations by default
  - this behavior is controlled by the new optimizer service configuration property `gpu.only_connected`
  - this behavior is only implemented for AMD GPUs at the moment